### PR TITLE
Proposed fix for CORE-2610

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertSetGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertSetGenerator.java
@@ -52,7 +52,9 @@ public class InsertSetGenerator extends AbstractSqlGenerator<InsertSetStatement>
 				generateHeader(sql, statement, database);
 			}
 		}
-		result.add(completeStatement(statement, sql));
+		if ( index > 0 ) {
+			result.add(completeStatement(statement, sql));
+		}
 
 		return result.toArray(new UnparsedSql[result.size()]);
 	}


### PR DESCRIPTION
Issue arised when sql contained only the header at that point, it would add a last wrong INSERT in result.